### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ information about Suji.
 
 
 ## Credits
- Code made with lots of ♥️ by [Dorian Javä Brown](www.dorianbrown.me)  
+ Code made with lots of ♥️ by [Dorian Javä Brown](https://www.dorianbrown.me)  
 
 
 ###### Development Status: [83%] 


### PR DESCRIPTION
The link was being rewritten by GitHub and thus pointing to https://github.com/ZEUSOFCS/Suji/blob/master/www.dorianbrown.me